### PR TITLE
Fix undefined COIN_COINUTILS_CHECKLEVEL

### DIFF
--- a/CoinUtils/src/CoinSmartPtr.hpp
+++ b/CoinUtils/src/CoinSmartPtr.hpp
@@ -419,7 +419,7 @@ public:
 	 * methods using the contained pointer. */
   T *operator->() const
   {
-#if COIN_COINUTILS_CHECKLEVEL > 0
+#if defined(COIN_COINUTILS_CHECKLEVEL) && COIN_COINUTILS_CHECKLEVEL > 0
     assert(ptr_);
 #endif
     return ptr_;


### PR DESCRIPTION
in the public header CoinSmartPtr.hpp COIN_COINUTILS_CHECKLEVEL is used, which is private, so we should check that it is defined first:
```
/usr/include/coin/CoinSmartPtr.hpp:422:5: warning: "COIN_COINUTILS_CHECKLEVEL" is not defined, evaluates to 0 [-Wundef]
  422 | #if COIN_COINUTILS_CHECKLEVEL > 0
```