### PR TITLE
Guard glibc-specific features with `__GLIBC__`

### DIFF
--- a/src/node_heap.cpp
+++ b/src/node_heap.cpp
@@ -6,8 +6,8 @@
 #include <limits>
 #include "node_heap.h"
 
-/* linux specific feature for debugging */
-#ifdef linux
+/* glibc-specific feature for debugging */
+#ifdef __GLIBC__
 #include <execinfo.h>
 void nh_print_trace(FILE *out, const char *file, int line);
 #endif
@@ -60,7 +60,7 @@ void nh_update(NodeHeap *npq, const size_t node, const size_t cost) {
 
     if (cost > npq->pq[pos].cost) {
         fprintf(stderr, "\nERROR:\n");
-#ifdef linux
+#ifdef __GLIBC__
         nh_print_trace(stderr, __FILE__, __LINE__);
 #else
         fprintf( stderr, "\t%s:%d\n", __FILE__, __LINE__ );
@@ -145,7 +145,7 @@ void nh_free(NodeHeap **nh) {
     (*nh) = NULL;
 }
 
-#ifdef linux
+#ifdef __GLIBC__
 void nh_print_trace(FILE *out, const char *file, int line) {
     const int max_depth = 100;
     int stack_depth;


### PR DESCRIPTION
`execinfo.h` is only in glibc, it won't work when using Musl as C library