### PR TITLE
Set RuntimeLibrary (Multithreaded DLL, etc) setting for VS2019 to default

### DIFF
--- a/MSVisualStudio/v16/libCoinUtils/libCoinUtils.vcxproj
+++ b/MSVisualStudio/v16/libCoinUtils/libCoinUtils.vcxproj
@@ -149,7 +149,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/wd4146 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
For libCoinUtils this PR sets RuntimeLibrary (Multithreaded DLL, etc.--how to link in the Microsoft Run-Time library MSVCRT / LIBCMT) for VS2019 to default values for all configurations by removing explicit values.

All Debug configs were at defaults, but Release were various, leading to link errors when linking multiple libraries together. These conflicts are prevented if all simply use the default (Multithreaded DLL (Debug or Release)). This has nothing to do with the result of the Configuration Type (static lib, dll, exe, etc.), but only how the MS runtimes are linked.