### PR TITLE
Fix spurious '+' in front of #endif in src/CoinMpsIO.cpp

### DIFF
--- a/src/CoinMpsIO.cpp
+++ b/src/CoinMpsIO.cpp
@@ -833,7 +833,7 @@ CoinMpsCardReader::nextField()
 	if (next[1] == ' ' || next[1] == '\t' || next[1] == '\0')
 	  position_ = eol_; // comment
       }
-+#endif
+#endif
       return section_;
     } else if (card_[0] != '*') {
       // not a comment


### PR DESCRIPTION
The file `src/CoinMpsIO.cpp` has a spurious `+` in front of the `#endif` directive. This leads to the compilation failing.