### PR TITLE
fix incorrect sizeof in CoinStaticConflictGraph.cpp

### DIFF
--- a/src/CoinStaticConflictGraph.cpp
+++ b/src/CoinStaticConflictGraph.cpp
@@ -144,7 +144,7 @@ CoinStaticConflictGraph::CoinStaticConflictGraph( const CoinConflictGraph *cgrap
   for ( size_t i=0 ; (i<n) ; ++i )
     newIdx[elements[i]] = i;
   
-  char *iv = (char *) calloc( size_, sizeof(char *) );
+  char *iv = (char *) calloc( size_, sizeof(char) );
   if (!iv) {
     fprintf( stderr, "no more memory.\n" );
     abort();


### PR DESCRIPTION
As sizeof(char*) >= sizeof(char) on virtually any relevant machine this probably did not cause memory issues, but allocating less memory shouldn't hurt.

Found by scan-build.