### PR TITLE
First attempt at adding linux-only github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+---
+name: Build source and run tests
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  test-linux:
+    name: Configure, compile and run tests on Ubuntu
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        build_static: [true, false]
+    env:
+      BUILD_STATIC: ${{ matrix.build_static }}
+      DEBUG: false
+      ASAN: false
+      ADD_CXXFLAGS: "-fvisibility=hidden"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.event.repository.name }}
+      - name: Checkout coinbrew
+        uses: actions/checkout@v2
+        with:
+          repository: coin-or/coinbrew
+          path: coinbrew
+      - name: Install required packages from package manager
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev
+      - name: Fetch dependencies
+        run: |
+          bash coinbrew/.ci/install_packages.sh
+          bash coinbrew/coinbrew fetch ${{ github.event.repository.name }} \
+          --no-prompt --skip-update \
+          --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack'
+      - name: Build project
+        run: |
+          source coinbrew/.ci/setup_environment.sh
+          bash coinbrew/coinbrew build ${{ github.event.repository.name }} \
+          --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' \
+          "${COMMON_ARGS[@]}" "${ADD_ARGS[@]}" "${DBG_ARGS[@]}" \
+          ADD_CXXFLAGS="${ADD_CXXFLAGS}" CC=${CC} CXX=${CXX}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ aclocal.m4*
 aclocal.m4.orig*
 autom4te*
 *~
+Makefile
+config.cache
+config.log
+config.status
+libtool


### PR DESCRIPTION
These actions will build on every recent version of ubuntu. Once full parity with travis is reached, I will remove the travis configs.

Also, add build artifacts to .gitignore.

~~NOTE: There is no way to test this without merging. Subsequent PRs, however, can be tested once GH Actions are turned on. Please try to review for correctness as much as possible.~~ JK Github Actions is a lot smarter than it used to be! https://github.com/coin-or/CoinUtils/actions

Current builds: ubuntu-16.04, ubuntu-18.04, ubuntu-20.04. For each distro, there are two builds, one with `BUILD_STATIC=true`, and another with `BUILD_STATIC=false`.