### PR TITLE
Eliminate superfluous calls to install_packages.sh and coinbrew fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,23 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ github.event.repository.name }}
+      - name: Install required packages from package manager
+        run: ${{ matrix.download_requirements }}
+      - name: Fetch Data-Sample repository
+        uses: actions/checkout@v2
+        with:
+          repository: coin-or-tools/Data-Sample
+          path: Data/Sample
+      - name: Fetch ThirdParty-Glpk repository
+        uses: actions/checkout@v2
+        with:
+          repository: coin-or-tools/ThirdParty-Glpk
+          path: ThirdParty/Glpk
       - name: Checkout coinbrew
         uses: actions/checkout@v2
         with:
           repository: coin-or/coinbrew
           path: coinbrew
-      - name: Install required packages from package manager
-        run: ${{ matrix.download_requirements }}
-      - name: Fetch dependencies
-        run: |
-          bash coinbrew/coinbrew fetch ${{ github.event.repository.name }} \
-          --no-prompt --skip-update \
-          --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack'
       - name: Build project
         run: |
           export ${{ matrix.flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         run: ${{ matrix.download_requirements }}
       - name: Fetch dependencies
         run: |
-          bash coinbrew/.ci/install_packages.sh
           bash coinbrew/coinbrew fetch ${{ github.event.repository.name }} \
           --no-prompt --skip-update \
           --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack'


### PR DESCRIPTION
I finally got around to taking a look at what this script is doing: https://github.com/coin-or/coinbrew/blob/master/.ci/install_packages.sh

It's not needed.

Also, I discovered a major issue with the usage of `coinbrew fetch`. This overwrites the checkout of CoinUtils with the release branch, meaning we are never building what is in the PR. I've replaced the dependency downloads for `coinbrew fetch` with additional steps to check out the required dependencies.