### PR TITLE
Add the Contributor Covenent as the code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,5 @@ documentation [here](http://coin-or.github.io/CoinUtils/Doxygen).
  * [Discussion formum](https://github.com/coin-or/CoinUtils/discussions)
  * [Report a bug](https://github.com/coin-or/CoinUtils/issues/new)
  * [Doxygen-generated html documentation](http://coin-or.github.io/CoinUtils/Doxygen)
+ * [Code of Conduct](https://www.coin-or.org/code-of-conduct/)
 


### PR DESCRIPTION
~~- Follow up task: create a private mailing list for COC violations reporting,
  and add users to that list (conduct@list.coin-or.org)~~
^ This is already done. The mailing list is code-of-conduct@coin-or.org.

Fixes #172.

I'm adding all of core contributors to this repository for approval to confirm that everyone agrees with this PR. Please add anyone that I might have missed! 

If we can get consensus, then I'll roll out this change to other repositories in the coin-or organization.