### PR TITLE
Replace github release action with gh cli

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -92,11 +92,8 @@ jobs:
           if-no-files-found: error
       - name: Upload package to release
         if: ${{ github.event_name == 'release'}}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./release.tar.gz
-          asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.platform_string }}.tar.gz
-          asset_content_type: application/gzip
+        run: |
+          mv release.tar.gz ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.platform_string }}.tar.gz
+          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.platform_string }}.tar.gz

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -89,15 +89,11 @@ jobs:
           if-no-files-found: error
       - name: Zip up dist contents for release
         if: ${{ github.event_name == 'release'}}
-        run: cd dist && zip -r ../release.zip *
+        run: cd dist && zip -r ../${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.package_suffix }}.zip *
         shell: msys2 {0}
       - name: Upload package to release
         if: ${{ github.event_name == 'release'}}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./release.zip
-          asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.package_suffix }}.zip
-          asset_content_type: application/gzip
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.package_suffix }}.zip

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ The CoinUtils development site is https://github.com/coin-or/CoinUtils.
 
 ## CURRENT BUILD STATUS
 
-[![Build Status](https://github.com/coin-or/CoinUtils/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/coin-or/CoinUtils/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Windows Builds](https://github.com/coin-or/CoinUtils/actions/workflows/windows-ci.yml/badge.svg?branch=master)](https://github.com/coin-or/CoinUtils/actions/workflows/windows-ci.yml?query=branch%3Amaster)
+
+[![Linux and MacOS Builds](https://github.com/coin-or/CoinUtils/actions/workflows/linux-ci.yml/badge.svg?branch=master)](https://github.com/coin-or/CoinUtils/actions/workflows/linux-ci.yml?query=branch%3Amaster)
 
 ## DOWNLOAD
 


### PR DESCRIPTION
Apparently the github action we were using for releasing isn't maintained:
https://github.com/actions/upload-release-asset/blob/main/README.md

Also, update the build status badges in the readme.