### PR TITLE
Revert release action

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -92,8 +92,11 @@ jobs:
           if-no-files-found: error
       - name: Upload package to release
         if: ${{ github.event_name == 'release'}}
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mv release.tar.gz ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.platform_string }}.tar.gz
-          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.platform_string }}.tar.gz
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release.tar.gz
+          asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.platform_string }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -91,11 +91,15 @@ jobs:
           if-no-files-found: error
       - name: Zip up dist contents for release
         if: ${{ github.event_name == 'release'}}
-        run: cd dist && zip -r ../${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.package_suffix }}.zip *
+        run: cd dist && zip -r ../release.zip *
         shell: msys2 {0}
       - name: Upload package to release
         if: ${{ github.event_name == 'release'}}
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.package_suffix }}.zip
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release.zip
+          asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}-${{ env.package_suffix }}.zip
+          asset_content_type: application/gzip

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - '*'
   release:
+    types:
+      - created
 
 jobs:
   test:


### PR DESCRIPTION
I decided to revert most of #178, in favour of the deprecated actions, since gh cli apparently needs to be run in the repository context, and might have other special requirements that I'm not aware of.

This PR also includes real bugfix for why windows was running so many builds upon release, which appeared to be failing.

Opened #179 as a separate issue for the future.