### PR TITLE
Tweak code in CoinPresolveDoubleton and constructors for CoinPostsolv…

### DIFF
--- a/src/CoinPostsolveMatrix.cpp
+++ b/src/CoinPostsolveMatrix.cpp
@@ -30,7 +30,9 @@
   Postpone allocation of space until we actually load the object.
 */
 
-CoinPostsolveMatrix::CoinPostsolveMatrix(int ncols_alloc, int nrows_alloc, CoinBigIndex nelems_alloc)
+CoinPostsolveMatrix::CoinPostsolveMatrix(
+    int ncols_alloc, int nrows_alloc, CoinBigIndex nelems_alloc,
+    const double *origRL, const double *origRU)
 
   : CoinPrePostsolveMatrix(ncols_alloc, nrows_alloc, nelems_alloc)
   , free_list_(0)
@@ -38,8 +40,8 @@ CoinPostsolveMatrix::CoinPostsolveMatrix(int ncols_alloc, int nrows_alloc, CoinB
   , link_(0)
   , cdone_(0)
   , rdone_(0)
-  , originalRowLower_(NULL)
-  , originalRowUpper_(NULL)
+  , originalRowLower_(origRL)
+  , originalRowUpper_(origRU)
 
 { /* nothing to do here */
 
@@ -71,7 +73,8 @@ CoinPostsolveMatrix::~CoinPostsolveMatrix()
   any memory already allocated.
 */
 
-void CoinPostsolveMatrix::assignPresolveToPostsolve(CoinPresolveMatrix *&preObj)
+void CoinPostsolveMatrix::assignPresolveToPostsolve(
+  CoinPresolveMatrix *&preObj, const double *origRL, const double *origRU)
 
 {
   /*
@@ -132,6 +135,13 @@ void CoinPostsolveMatrix::assignPresolveToPostsolve(CoinPresolveMatrix *&preObj)
   preObj->colstat_ = 0;
   rowstat_ = preObj->rowstat_;
   preObj->rowstat_ = 0;
+/*
+  (Optional) vectors holding the row upper and lower bounds of the original
+  problem. Check before we assign, we don't want to overwrite values supplied
+  via the constructor with a null.
+*/
+  if (origRL) { originalRowLower_ = origRL ; }
+  if (origRU) { originalRowUpper_ = origRU ; }
   /*
   The CoinPostsolveMatrix comes with messages and a handler, but replace them
   with the versions from the CoinPresolveObject, in case they've been

--- a/src/CoinPresolveDoubleton.cpp
+++ b/src/CoinPresolveDoubleton.cpp
@@ -1046,7 +1046,9 @@ const CoinPresolveAction
 
     rlo[tgtrow] = 0.0;
     rup[tgtrow] = 0.0;
-    prob->setRowStatus(tgtrow,CoinPrePostsolveMatrix::atLowerBound);
+    if (rowstat) {
+      prob->setRowStatus(tgtrow,CoinPrePostsolveMatrix::atLowerBound);
+    }
 
     zeros[nzeros++] = tgtcolx;
 
@@ -1679,7 +1681,8 @@ void doubleton_action::postsolve(CoinPostsolveMatrix *prob) const
 	rcosts[jcoly] = djy - rowduals[irow] * coeffy;
 	rcosts[jcolx] = 0.0;
       }
-      if (prob->originalRowLower_[irow] != prob->originalRowUpper_[irow]
+      if (prob->originalRowLower_ &&
+          prob->originalRowLower_[irow] != prob->originalRowUpper_[irow]
 	  && !basicx) {
 	// row was not originally == (? dual)
 	// 0 lower, 1 between, 2 upper

--- a/src/CoinPresolveMatrix.hpp
+++ b/src/CoinPresolveMatrix.hpp
@@ -892,7 +892,8 @@ class COINUTILSLIB_EXPORT CoinPresolveMatrix : public CoinPrePostsolveMatrix
 
     See CoinPostsolveMatrix::assignPresolveToPostsolve.
   */
-  friend void assignPresolveToPostsolve(CoinPresolveMatrix *&preObj);
+  friend void assignPresolveToPostsolve(CoinPresolveMatrix *&preObj,
+    const double *origRL, const double *origRU);
 
   /*! \name Functions to load the problem representation
   */
@@ -1505,9 +1506,14 @@ class COINUTILSLIB_EXPORT CoinPostsolveMatrix : public CoinPrePostsolveMatrix
     This constructor creates an empty object which must then be loaded.
     On the other hand, it doesn't assume that the client is an
     OsiSolverInterface.
+
+    If provided, parameters \c origRL and \c origRU should be the row lower
+    and upper bound vectors of the original problem. These are not required
+    but if provided are used to improve the presolved system.
   */
   CoinPostsolveMatrix(int ncols_alloc, int nrows_alloc,
-    CoinBigIndex nelems_alloc);
+    CoinBigIndex nelems_alloc,
+    const double *origRL = 0, const double *origRU = 0);
 
   /*! \brief Load an empty CoinPostsolveMatrix from a CoinPresolveMatrix
 
@@ -1516,10 +1522,14 @@ class COINUTILSLIB_EXPORT CoinPostsolveMatrix : public CoinPrePostsolveMatrix
     object and completes initialisation of the CoinPostsolveMatrix object.
     The empty shell of the CoinPresolveMatrix object is destroyed.
 
+    As noted for CoinPostsolveMatrix(), you can supply optional vectors
+    \c origRL and \c origRU for the row lower and upper bounds.
+
     The routine expects an empty CoinPostsolveMatrix object. If handed a loaded
     object, a lot of memory will leak.
   */
-  void assignPresolveToPostsolve(CoinPresolveMatrix *&preObj);
+  void assignPresolveToPostsolve(CoinPresolveMatrix *&preObj,
+    const double *origRL = 0, const double *origRU = 0);
 
   /// Destructor
   ~CoinPostsolveMatrix();
@@ -1548,6 +1558,18 @@ class COINUTILSLIB_EXPORT CoinPostsolveMatrix : public CoinPrePostsolveMatrix
 
   //@}
 
+  /*! \name Row bounds from the original problem
+
+    (Optional) If provided, these vectors are used during postsolve to tighten
+    the presolved system.
+  */
+  //@{
+  /// Pointer to row lower bounds from the original problem
+  const double *originalRowLower_;
+  /// Pointer to row upper bounds from the original problem
+  const double *originalRowUpper_;
+  //@}
+
   /*! \name Debugging aids
 
      These arrays are allocated only when CoinPresolve is compiled with
@@ -1557,14 +1579,10 @@ class COINUTILSLIB_EXPORT CoinPostsolveMatrix : public CoinPrePostsolveMatrix
   //@{
   char *cdone_;
   char *rdone_;
-  //@}
 
   /// debug
   void check_nbasic();
-  /// Pointer to rowLower in original model
-  const double *originalRowLower_;
-  /// Pointer to rowUpper in original model
-  const double *originalRowUpper_;
+  //@}
 };
 
 /*! \defgroup MtxManip Presolve Matrix Manipulation Functions


### PR DESCRIPTION
…eMatrix

to cleanly integrate the use of original constraint system row bounds in
doubleton_action::postsolve. Fix an unguarded use of row status.

CoinUtils Issue 189 (https://github.com/coin-or/CoinUtils/issues/189#issue-1152390814) says a little more.