### PR TITLE
Fix warnings

### DIFF
--- a/CoinUtils/src/CoinModel.cpp
+++ b/CoinUtils/src/CoinModel.cpp
@@ -3766,8 +3766,10 @@ void CoinModel::badType() const
 //#############################################################################
 // Methods to input a problem
 //#############################################################################
+#if 0 // unused local function
 /** A function to convert from the lb/ub style of constraint
     definition to the sense/rhs/range style */
+static
 void convertBoundToSense(const double lower, const double upper,
   char &sense, double &right,
   double &range)
@@ -3797,10 +3799,12 @@ void convertBoundToSense(const double lower, const double upper,
     }
   }
 }
+#endif
 
 //-----------------------------------------------------------------------------
 /** A function to convert from the sense/rhs/range style of
     constraint definition to the lb/ub style */
+static
 void convertSenseToBound(const char sense, const double right,
   const double range,
   double &lower, double &upper)

--- a/CoinUtils/src/CoinOslFactorization2.cpp
+++ b/CoinUtils/src/CoinOslFactorization2.cpp
@@ -328,6 +328,7 @@ static int c_ekkscmv(COIN_REGISTER const EKKfactinfo *COIN_RESTRICT2 fact, int n
 
   return static_cast< int >(mptr - mptrsave);
 } /* c_ekkscmv */
+static
 double c_ekkputl(const EKKfactinfo *COIN_RESTRICT2 fact,
   const int *COIN_RESTRICT mpt2,
   double *COIN_RESTRICT dwork1,
@@ -368,6 +369,7 @@ double c_ekkputl(const EKKfactinfo *COIN_RESTRICT2 fact,
 /* making this static seems to slow code down!
    may be being inlined
 */
+static
 int c_ekkputl2(const EKKfactinfo *COIN_RESTRICT2 fact,
   double *COIN_RESTRICT dwork1,
   double *del3p,

--- a/CoinUtils/src/CoinOslFactorization3.cpp
+++ b/CoinUtils/src/CoinOslFactorization3.cpp
@@ -165,6 +165,7 @@ static void c_ekkafpv(int *hentry, int *hcoli,
  * so we maintain it as we shorten rows and removing columns altogether.
  *
  */
+static
 int c_ekkcsin(EKKfactinfo *fact,
   EKKHlink *rlink, EKKHlink *clink,
 
@@ -303,6 +304,7 @@ int c_ekkcsin(EKKfactinfo *fact,
 /*      7: pivot element too small */
 /*     -52: system error at label 220 (ipivot not found) */
 /*     -53: system error at label 400 (jpivot not found) */
+static
 int c_ekkrsin(EKKfactinfo *fact,
   EKKHlink *rlink, EKKHlink *clink,
   EKKHlink *mwork, int nfirst,
@@ -509,6 +511,7 @@ int c_ekkrsin(EKKfactinfo *fact,
   return (irtcod);
 } /* c_ekkrsin */
 
+static
 int c_ekkfpvt(const EKKfactinfo *fact,
   EKKHlink *rlink, EKKHlink *clink,
   int *nsingp, int *xrejctp,
@@ -648,6 +651,7 @@ L900:
   *xjpivtp = jpivot;
   return (irtcod);
 } /* c_ekkfpvt */
+static
 void c_ekkprpv(EKKfactinfo *fact,
   EKKHlink *rlink, EKKHlink *clink,
 

--- a/CoinUtils/src/CoinPresolveImpliedFree.cpp
+++ b/CoinUtils/src/CoinPresolveImpliedFree.cpp
@@ -21,6 +21,7 @@
 #if PRESOLVE_DEBUG > 0 || PRESOLVE_CONSISTENCY > 0
 #include "CoinPresolvePsdebug.hpp"
 #endif
+static
 int check_row(CoinBigIndex *mrstrt,
   double *rowels, int *hcol, int *hinrow,
   double coeff_factor, double kill_ratio, int irowx, int irowy, int &numberBadElements)

--- a/CoinUtils/src/CoinPresolveTripleton.cpp
+++ b/CoinUtils/src/CoinPresolveTripleton.cpp
@@ -1065,6 +1065,7 @@ tripleton_action::~tripleton_action()
 
 static double *tripleton_mult;
 static int *tripleton_id;
+static
 void check_tripletons(const CoinPresolveAction *paction)
 {
   const CoinPresolveAction *paction0 = paction;

--- a/CoinUtils/src/CoinStructuredModel.cpp
+++ b/CoinUtils/src/CoinStructuredModel.cpp
@@ -740,7 +740,6 @@ int CoinStructuredModel::decompose(const CoinPackedMatrix &matrix,
   bool wantDecomposition = type > 2;
   type %= 10;
   if (type == 1) { // Try master at top and bottom
-    bool goodDW = true;
     // get row copy
     CoinPackedMatrix rowCopy = matrix;
     rowCopy.reverseOrdering();
@@ -978,7 +977,6 @@ int CoinStructuredModel::decompose(const CoinPackedMatrix &matrix,
           rowBlock[stack[i]] = -1;
       }
       if (nMaster * 2 > numberRows) {
-        goodDW = false;
         sprintf(generalPrint, "%d rows out of %d would be in master - no good",
           nMaster, numberRows);
         handler_->message(COIN_GENERAL_WARNING, messages_) << generalPrint << CoinMessageEol;
@@ -1314,7 +1312,6 @@ int CoinStructuredModel::decompose(const CoinPackedMatrix &matrix,
     delete[] rowUp;
   } else if (type == 2) {
     // Try master at beginning and end
-    bool goodBenders = true;
     // get row copy
     CoinPackedMatrix rowCopy = matrix;
     rowCopy.reverseOrdering();
@@ -1526,7 +1523,6 @@ int CoinStructuredModel::decompose(const CoinPackedMatrix &matrix,
           columnBlock[stack[i]] = -1;
       }
       if (nMaster * 2 > numberColumns) {
-        goodBenders = false;
         sprintf(generalPrint, "%d columns out of %d would be in master - no good",
           nMaster, numberColumns);
         handler_->message(COIN_GENERAL_WARNING, messages_) << generalPrint << CoinMessageEol;


### PR DESCRIPTION
Fix some harmless compiler warnings by making local methods static and removing unused code/vars.