### PR TITLE
Fix clang warnings

### DIFF
--- a/CoinUtils/src/CoinPresolveDupcol.hpp
+++ b/CoinUtils/src/CoinPresolveDupcol.hpp
@@ -91,21 +91,21 @@ class duprow_action : public CoinPresolveAction {
     double ubound;
   };
 
-  const int nactions_;
-  const action *const actions_;
+  //const int nactions_;
+  //const action *const actions_;
 
   duprow_action()
     : CoinPresolveAction(NULL)
-    , nactions_(0)
-    , actions_(NULL)
+    //, nactions_(0)
+    //, actions_(NULL)
   {
   }
   duprow_action(int nactions,
     const action *actions,
     const CoinPresolveAction *next)
     : CoinPresolveAction(next)
-    , nactions_(nactions)
-    , actions_(actions)
+    //, nactions_(nactions)
+    //, actions_(actions)
   {
   }
 

--- a/CoinUtils/src/CoinPresolveImpliedFree.cpp
+++ b/CoinUtils/src/CoinPresolveImpliedFree.cpp
@@ -940,10 +940,10 @@ const CoinPresolveAction *implied_free_action::presolve(
 	  Count up the total number of coefficients in entangled rows and mark them as
 	  contaminated.
 	*/
-        int ntotels = 0;
+        //int ntotels = 0;
         for (CoinBigIndex kcol = tgtcs; kcol < tgtce; ++kcol) {
           const int i = rowIndices[kcol];
-          ntotels += rowLengths[i];
+          //ntotels += rowLengths[i];
           PRESOLVEASSERT(!prob->rowUsed(i));
           prob->setRowUsed(i);
           rowsUsed[nRowsUsed++] = i;

--- a/CoinUtils/src/CoinPresolveSingleton.cpp
+++ b/CoinUtils/src/CoinPresolveSingleton.cpp
@@ -590,7 +590,9 @@ slack_singleton_action::presolve(CoinPresolveMatrix *prob,
   int *fixed_cols = new int[numberLook];
   int nfixed_cols = 0;
   int nWithCosts = 0;
+#ifdef COIN_DEVELOP
   double costOffset = 0.0;
+#endif
   for (iLook = 0; iLook < numberLook; iLook++) {
     int iCol = look[iLook];
     if (dcost[iCol])
@@ -743,7 +745,9 @@ slack_singleton_action::presolve(CoinPresolveMatrix *prob,
           rowObjective[iRow] = -dcost[iCol] / coeff;
           nWithCosts++;
           // adjust offset
+#ifdef COIN_DEVELOP
           costOffset += currentLower * rowObjective[iRow];
+#endif
           prob->dobias_ -= currentLower * rowObjective[iRow];
         }
         if (sol) {

--- a/CoinUtils/src/CoinPresolveTripleton.cpp
+++ b/CoinUtils/src/CoinPresolveTripleton.cpp
@@ -1063,6 +1063,7 @@ tripleton_action::~tripleton_action()
   deleteAction(actions_, action *);
 }
 
+#if 0
 static double *tripleton_mult;
 static int *tripleton_id;
 static
@@ -1087,6 +1088,7 @@ void check_tripletons(const CoinPresolveAction *paction)
     }
   }
 }
+#endif
 
 /* vi: softtabstop=2 shiftwidth=2 expandtab tabstop=2
 */

--- a/CoinUtils/src/CoinPresolveUseless.cpp
+++ b/CoinUtils/src/CoinPresolveUseless.cpp
@@ -150,7 +150,7 @@ const CoinPresolveAction *testRedundant(CoinPresolveMatrix *prob,
 
   int numberInfeasible = 0;
   int numberChanged = 0;
-  int totalTightened = 0;
+  //int totalTightened = 0;
   int numberCheck = -1;
 
   const int MAXPASS = 10;
@@ -456,7 +456,7 @@ const CoinPresolveAction *testRedundant(CoinPresolveMatrix *prob,
       }
     }
 
-    totalTightened += numberChanged;
+    //totalTightened += numberChanged;
     if (iPass == 1)
       numberCheck = CoinMax(10, numberChanged >> 5);
     if (numberInfeasible) {


### PR DESCRIPTION
Fixes warnings that came up with clang 14 on macOS 13. Except for the deprecation of sprintf, of course.