### PR TITLE
Add VS2022 and its windows-ci to stable 2.11

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -89,7 +89,6 @@ jobs:
         run: |
           head_ref=${{ github.head_ref }}
           echo "safe_head_ref=${head_ref//\//-}" >> $GITHUB_ENV
-        shell: msys2 {0}
       - name: Upload Artifact
         if: ${{ github.event_name == 'pull_request'}}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -82,11 +82,19 @@ jobs:
           [[ ${{ matrix.build_static }} == "true" ]] && buildtype=static || buildtype=
           platform_str=`python3 tools/hsf_get_platform.py -b $buildtype`
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
+      - name: Generate safe branch name
+        # Replace forward slash in branch name head_ref, such as stable/1.1 
+        # because slash is not allowed in artifact name.
+        if: ${{ matrix.arch != 'msvc' }}
+        run: |
+          head_ref=${{ github.head_ref }}
+          echo "safe_head_ref=${head_ref//\//-}" >> $GITHUB_ENV
+        shell: msys2 {0}
       - name: Upload Artifact
         if: ${{ github.event_name == 'pull_request'}}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.platform_string }}.tar.gz
+          name: ${{ github.event.repository.name }}-${{  env.safe_head_ref }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz
           if-no-files-found: error
       - name: Upload package to release

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Generate safe branch name
         # Replace forward slash in branch name head_ref, such as stable/1.1 
         # because slash is not allowed in artifact name.
-        if: ${{ matrix.arch != 'msvc' }}
         run: |
           head_ref=${{ github.head_ref }}
           echo "safe_head_ref=${head_ref//\//-}" >> $GITHUB_ENV

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -82,17 +82,11 @@ jobs:
           [[ ${{ matrix.build_static }} == "true" ]] && buildtype=static || buildtype=
           platform_str=`python3 tools/hsf_get_platform.py -b $buildtype`
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
-      - name: Generate safe branch name
-        # Replace forward slash in branch name head_ref, such as stable/1.1 
-        # because slash is not allowed in artifact name.
-        run: |
-          head_ref=${{ github.head_ref }}
-          echo "safe_head_ref=${head_ref//\//-}" >> $GITHUB_ENV
       - name: Upload Artifact
         if: ${{ github.event_name == 'pull_request'}}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.event.repository.name }}-${{  env.safe_head_ref }}-${{ env.platform_string }}.tar.gz
+          name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz
           if-no-files-found: error
       - name: Upload package to release

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -131,7 +131,6 @@ jobs:
       - name: Generate safe branch name
         # Replace forward slash in branch name head_ref, such as stable/1.1 
         # because slash is not allowed in artifact name.
-        if: ${{ matrix.arch != 'msvc' }}
         run: |
           head_ref=${{ github.head_ref }}
           echo "safe_head_ref=${head_ref//\//-}" >> $GITHUB_ENV

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,6 +26,7 @@ jobs:
           { os: windows-2019, arch: i686, msystem: mingw32, debug: false, suffix: "" },
           { os: windows-2019, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
           { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2022, arch: msvs, msystem: mingw64, debug: false, suffix: "" },
         ]
     steps:
       - name: Checkout source
@@ -40,11 +41,14 @@ jobs:
       - name: Set up msvc
         if: ${{ matrix.arch == 'msvc' }}
         uses: ilammy/msvc-dev-cmd@v1
+      - name: Set up for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        uses: microsoft/setup-msbuild@v1.1
       - name: Set correct host flag and install requirements
+        if: ${{ matrix.arch != 'msvc' && matrix.arch != 'msvs' }}
         run: |
           echo "host_flag=--host=${{ matrix.arch }}-w64-mingw32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           C:\msys64\usr\bin\pacman -S mingw-w64-${{ matrix.arch }}-lapack mingw-w64-${{ matrix.arch }}-winpthreads-git mingw-w64-${{ matrix.arch }}-readline mingw-w64-${{ matrix.arch }}-suitesparse mingw-w64-${{ matrix.arch }}-metis --noconfirm
-        if: ${{ matrix.arch != 'msvc' }}
       - name: Set up msys with ${{ matrix.msystem }}
         uses: msys2/setup-msys2@v2
         with:
@@ -55,7 +59,42 @@ jobs:
             zip
           path-type: inherit
           msystem: ${{ matrix.msystem }}
-      - name: Build project
+      - name: Fetch project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        run: |
+          ADD_ARGS=()
+          ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
+          ./coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update "${ADD_ARGS[@]}"
+          echo "##################################################"
+          echo "### Extracting Netlib and Miplib3 if available"
+          if [ -d "./Data/Netlib/" ]; then gunzip ./Data/Netlib/*.gz; fi
+          if [ -d "./Data/Miplib3/" ]; then gunzip ./Data/Miplib3/*.gz; fi
+          echo "##################################################"       
+        shell: msys2 {0}
+      - name: Build project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          msbuild ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=Release /p:Platform=x64 /m
+      - name: Test project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
+      - name: Install project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          mkdir dist
+          copy ${{ github.event.repository.name }}\README.* dist\.
+          copy ${{ github.event.repository.name }}\AUTHORS.* dist\.
+          copy ${{ github.event.repository.name }}\LICENSE.* dist\.
+          mkdir dist\bin
+          copy ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release\*.exe dist\bin\.
+          mkdir dist\share\coin\Data
+          xcopy Data dist\share\coin\Data\. /s /e
+      - name: Build project using coinbrew
+        if: ${{ matrix.arch != 'msvs' }}
         run: |
           ADD_ARGS=()
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -128,11 +128,19 @@ jobs:
           echo "package_suffix=${{ matrix.arch }}-w64-${{ matrix.msystem }}${{ matrix.suffix }}" >> $GITHUB_ENV
         shell: msys2 {0}
         if: ${{ matrix.arch != 'msvc' }}
+      - name: Generate safe branch name
+        # Replace forward slash in branch name head_ref, such as stable/1.1 
+        # because slash is not allowed in artifact name.
+        if: ${{ matrix.arch != 'msvc' }}
+        run: |
+          head_ref=${{ github.head_ref }}
+          echo "safe_head_ref=${head_ref//\//-}" >> $GITHUB_ENV
+        shell: msys2 {0}
       - name: Upload artifact
         if: ${{ github.event_name == 'pull_request'}}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.package_suffix }}
+          name: ${{ github.event.repository.name }}-${{ env.safe_head_ref }}-${{ env.package_suffix }}
           path: dist
           if-no-files-found: error
       - name: Zip up dist contents for release

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -91,8 +91,10 @@ jobs:
           copy ${{ github.event.repository.name }}\LICENSE.* dist\.
           mkdir dist\bin
           copy ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release\*.exe dist\bin\.
-          mkdir dist\share\coin\Data
-          xcopy Data dist\share\coin\Data\. /s /e
+          mkdir dist\share
+          if exist .\Data\Sample xcopy .\Data\Sample dist\share\coin-or-sample /i
+          if exist .\Data\Netlib xcopy .\Data\Netlib dist\share\coin-or-netlib /i
+          if exist .\Data\Miplib3 xcopy .\Data\Miplib3 dist\share\coin-or-miplib3 /i
       - name: Build project using coinbrew
         if: ${{ matrix.arch != 'msvs' }}
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd
         run: |
-          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
+          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
       - name: Install project for msvs
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,18 @@ config.log
 config.status
 libtool
 dist
+
+# Ignore VS files
+*.suo
+*.db
+*.bak
+*.user
+**/.vs/
+**/MSVisualStudio/**/Release/
+**/MSVisualStudio/**/ReleaseParallel/
+**/MSVisualStudio/**/Debug/
+
+# Ignore files created during unit tests
+**/MSVisualStudio/**/*.mps
+**/MSVisualStudio/**/*.lp
+**/MSVisualStudio/**/*.out

--- a/CoinUtils/MSVisualStudio/v17/CoinUtils.sln
+++ b/CoinUtils/MSVisualStudio/v17/CoinUtils.sln
@@ -1,0 +1,65 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32804.467
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCoinUtils", "libCoinUtils\libCoinUtils.vcxproj", "{6D2EF92A-D693-47E3-A325-A686E78C5FFD}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CoinUtilsUnitTest", "CoinUtilsUnitTest\CoinUtilsUnitTest.vcxproj", "{FCF90EF8-93AE-482A-9B55-018B8338B99D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B8AB58C7-FB01-45B3-97CC-3F3E6583BF85}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.gitignore = ..\..\..\.gitignore
+		..\..\..\LICENSE = ..\..\..\LICENSE
+		..\..\..\README.md = ..\..\..\README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E712FDE2-9810-416F-B615-FD827259BABA}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.github\workflows\linux-ci.yml = ..\..\..\.github\workflows\linux-ci.yml
+		..\..\..\.github\workflows\release.yml = ..\..\..\.github\workflows\release.yml
+		..\..\..\.github\workflows\windows-ci.yml = ..\..\..\.github\workflows\windows-ci.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{7032C4C9-B7AE-42F2-A4C0-26F1A9F054F1}"
+	ProjectSection(SolutionItems) = preProject
+		CoinUtilsTest.cmd = CoinUtilsTest.cmd
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x64.ActiveCfg = Debug|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x64.Build.0 = Debug|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x86.ActiveCfg = Debug|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x86.Build.0 = Debug|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x64.ActiveCfg = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x64.Build.0 = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x86.ActiveCfg = Release|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x86.Build.0 = Release|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x64.ActiveCfg = Debug|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x64.Build.0 = Debug|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x86.ActiveCfg = Debug|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x86.Build.0 = Debug|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x64.ActiveCfg = Release|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x64.Build.0 = Release|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x86.ActiveCfg = Release|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D} = {7032C4C9-B7AE-42F2-A4C0-26F1A9F054F1}
+		{E712FDE2-9810-416F-B615-FD827259BABA} = {B8AB58C7-FB01-45B3-97CC-3F3E6583BF85}
+		{7032C4C9-B7AE-42F2-A4C0-26F1A9F054F1} = {B8AB58C7-FB01-45B3-97CC-3F3E6583BF85}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {47CE0831-9FE3-4146-A085-43BC3B8AE89A}
+	EndGlobalSection
+EndGlobal

--- a/CoinUtils/MSVisualStudio/v17/CoinUtilsTest.cmd
+++ b/CoinUtils/MSVisualStudio/v17/CoinUtilsTest.cmd
@@ -1,0 +1,43 @@
+@REM This file will run command line tests, comparable to test\makefile.am
+@REM The name of this file xxTest.cmd and the parameters are standardized for windows-ci.yml
+@REM The usage message describes what parameters are used.
+
+@echo off
+SET "BINDIR=%~1"
+SET "SAMPLEDIR=%~2"
+SET "NETLIBDIR=%~3"
+SET "MIPLIBDIR=%~4"
+
+echo INFO: Running %0 %*
+echo INFO: Using bindir '%BINDIR%' and sampledir '%SAMPLEDIR%'.
+echo INFO: Netlibdir '%NETLIBDIR%' and miplibdir '%MIPLIBDIR%' are ignored for these tests.
+
+if "%BINDIR%"=="" echo ERROR: No bindir given. && goto :usage
+if not exist "%BINDIR%" echo ERROR: Folder bindir %BINDIR% does not exist. && goto :usage
+
+if "%SAMPLEDIR%"=="" echo ERROR: No sampledir given. && goto :usage
+if not exist %SAMPLEDIR% echo ERROR: Folder sampledir %SAMPLEDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %SAMPLEDIR% cannot contain spaces. && goto :usage
+
+goto :test
+
+:usage
+echo INFO: Usage %0 ^<bindir^> ^<sampledir^>
+echo INFO: where ^<bindir^> contains the executables, sampledir the sample files.
+echo INFO: This script runs automated test.
+echo INFO: The ^<sampledir^> must not contain spaces!
+echo INFO: For example: %0 "D:\Some Directory\" ..\..\samples\
+goto :error
+
+:error
+echo ERROR: An error occurred while running the tests!
+echo INFO: Finished Tests but failed
+exit /b 1
+
+:test
+echo INFO: Starting Tests
+
+"%BINDIR%\CoinUtilsUnitTest.exe" -mpsDir=%SAMPLEDIR%  
+if not %errorlevel%==0 echo ERROR: Error running CoinUtilsUnitTest.exe tests. && goto :error
+
+echo INFO: Finished Tests successfully (%ERRORLEVEL%)

--- a/CoinUtils/MSVisualStudio/v17/CoinUtilsUnitTest/CoinUtilsUnitTest.vcxproj
+++ b/CoinUtils/MSVisualStudio/v17/CoinUtilsUnitTest/CoinUtilsUnitTest.vcxproj
@@ -88,7 +88,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -103,7 +103,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,7 +118,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,7 +133,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/CoinUtils/MSVisualStudio/v17/CoinUtilsUnitTest/CoinUtilsUnitTest.vcxproj
+++ b/CoinUtils/MSVisualStudio/v17/CoinUtilsUnitTest/CoinUtilsUnitTest.vcxproj
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{fcf90ef8-93ae-482a-9b55-018b8338b99d}</ProjectGuid>
+    <RootNamespace>CoinUtilsUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;..\..\..\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\CoinDenseVectorTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinErrorTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinIndexedVectorTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinLpIOTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinMessageHandlerTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinModelTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinMpsIOTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinPackedMatrixTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinPackedVectorTest.cpp" />
+    <ClCompile Include="..\..\..\test\CoinShallowPackedVectorTest.cpp" />
+    <ClCompile Include="..\..\..\test\unitTest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/CoinUtils/MSVisualStudio/v17/libCoinUtils/libCoinUtils.vcxproj
+++ b/CoinUtils/MSVisualStudio/v17/libCoinUtils/libCoinUtils.vcxproj
@@ -91,7 +91,7 @@
       <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -107,7 +107,7 @@
       <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4146 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -126,7 +126,7 @@
       <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -147,7 +147,7 @@
       <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/wd4146 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/CoinUtils/MSVisualStudio/v17/libCoinUtils/libCoinUtils.vcxproj
+++ b/CoinUtils/MSVisualStudio/v17/libCoinUtils/libCoinUtils.vcxproj
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{6D2EF92A-D693-47E3-A325-A686E78C5FFD}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libCoinUtils</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/wd4146 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>COINUTILS_BUILD;_LIB;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/wd4146 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\CoinAlloc.cpp" />
+    <ClCompile Include="..\..\..\src\CoinBuild.cpp" />
+    <ClCompile Include="..\..\..\src\CoinDenseFactorization.cpp" />
+    <ClCompile Include="..\..\..\src\CoinDenseVector.cpp" />
+    <ClCompile Include="..\..\..\src\CoinError.cpp" />
+    <ClCompile Include="..\..\..\src\CoinFactorization1.cpp" />
+    <ClCompile Include="..\..\..\src\CoinFactorization2.cpp" />
+    <ClCompile Include="..\..\..\src\CoinFactorization3.cpp" />
+    <ClCompile Include="..\..\..\src\CoinFactorization4.cpp" />
+    <ClCompile Include="..\..\..\src\CoinFileIO.cpp" />
+    <ClCompile Include="..\..\..\src\CoinFinite.cpp" />
+    <ClCompile Include="..\..\..\src\CoinIndexedVector.cpp" />
+    <ClCompile Include="..\..\..\src\CoinLpIO.cpp" />
+    <ClCompile Include="..\..\..\src\CoinMessage.cpp" />
+    <ClCompile Include="..\..\..\src\CoinMessageHandler.cpp" />
+    <ClCompile Include="..\..\..\src\CoinModel.cpp" />
+    <ClCompile Include="..\..\..\src\CoinModelUseful.cpp" />
+    <ClCompile Include="..\..\..\src\CoinModelUseful2.cpp" />
+    <ClCompile Include="..\..\..\src\CoinMpsIO.cpp" />
+    <ClCompile Include="..\..\..\src\CoinOslFactorization.cpp" />
+    <ClCompile Include="..\..\..\src\CoinOslFactorization2.cpp" />
+    <ClCompile Include="..\..\..\src\CoinOslFactorization3.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPackedMatrix.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPackedVector.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPackedVectorBase.cpp" />
+    <ClCompile Include="..\..\..\src\CoinParam.cpp" />
+    <ClCompile Include="..\..\..\src\CoinParamUtils.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPostsolveMatrix.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPrePostsolveMatrix.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveDoubleton.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveDual.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveDupcol.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveEmpty.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveFixed.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveForcing.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveHelperFunctions.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveImpliedFree.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveIsolated.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveMatrix.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveMonitor.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolvePsdebug.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveSingleton.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveSubst.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveTighten.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveTripleton.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveUseless.cpp" />
+    <ClCompile Include="..\..\..\src\CoinPresolveZeros.cpp" />
+    <ClCompile Include="..\..\..\src\CoinRational.cpp" />
+    <ClCompile Include="..\..\..\src\CoinSearchTree.cpp" />
+    <ClCompile Include="..\..\..\src\CoinShallowPackedVector.cpp" />
+    <ClCompile Include="..\..\..\src\CoinSimpFactorization.cpp" />
+    <ClCompile Include="..\..\..\src\CoinSnapshot.cpp" />
+    <ClCompile Include="..\..\..\src\CoinStructuredModel.cpp" />
+    <ClCompile Include="..\..\..\src\CoinWarmStartBasis.cpp" />
+    <ClCompile Include="..\..\..\src\CoinWarmStartDual.cpp" />
+    <ClCompile Include="..\..\..\src\CoinWarmStartPrimalDual.cpp" />
+    <ClCompile Include="..\..\..\src\CoinWarmStartVector.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\CoinUtilsConfig.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/CoinUtils/src/configall_system.h
+++ b/CoinUtils/src/configall_system.h
@@ -1,0 +1,13 @@
+/*
+ * This header file is included by the *Config.h in the individual
+ * COIN packages when the code is compiled in a setting that doesn't
+ * use the configure script (i.e., HAVE_CONFIG_H is not defined).
+ * This header file includes the system and compile dependent header
+ * file defining macros that depend on what compiler is used.
+ */
+
+#ifdef _MSC_VER
+# include "configall_system_msc.h"
+#else
+# error "Trying to use configall_system for unknown compiler."
+#endif

--- a/CoinUtils/src/configall_system_msc.h
+++ b/CoinUtils/src/configall_system_msc.h
@@ -1,0 +1,145 @@
+/* This is the header file for the Microsoft compiler, defining all
+ * system and compiler dependent configuration macros */
+
+/* Define to dummy `main' function (if any) required to link to the Fortran
+   libraries. */
+/* #undef F77_DUMMY_MAIN */
+
+#ifndef COIN_USE_F2C
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+# define F77_FUNC(name,NAME) NAME
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+# define F77_FUNC_(name,NAME) NAME
+#else
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+# define F77_FUNC(name,NAME) name ## _
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+# define F77_FUNC_(name,NAME) name ## __
+#endif
+
+/* Define if F77 and FC dummy `main' functions are identical. */
+/* #undef FC_DUMMY_MAIN_EQ_F77 */
+
+/* Define to 1 if you have the <assert.h> header file. */
+/* #undef HAVE_ASSERT_H */
+
+/* Define to 1 if you have the <cassert> header file. */
+#define HAVE_CASSERT 1
+
+/* Define to 1 if you have the <cctype> header file. */
+#define HAVE_CCTYPE 1
+
+/* Define to 1 if you have the <cfloat> header file. */
+#define HAVE_CFLOAT 1
+
+/* Define to 1 if you have the <cieeefp> header file. */
+/* #undef HAVE_CIEEEFP */
+
+/* Define to 1 if you have the <cmath> header file. */
+#define HAVE_CMATH 1
+
+/* Define to 1 if you have the <cstdarg> header file. */
+#define HAVE_CSTDARG 1
+
+/* Define to 1 if you have the <cstdio> header file. */
+#define HAVE_CSTDIO 1
+
+/* Define to 1 if you have the <cstdlib> header file. */
+#define HAVE_CSTDLIB 1
+
+/* Define to 1 if you have the <cstring> header file. */
+#define HAVE_CSTRING 1
+
+/* Define to 1 if you have the <ctime> header file. */
+#define HAVE_CTIME 1
+
+/* Define to 1 if you have the <cstddef> header file. */
+#define HAVE_CSTDDEF 1
+
+/* Define to 1 if you have the <ctype.h> header file. */
+/* #undef HAVE_CTYPE_H */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if function drand48 is available */
+/* #undef HAVE_DRAND48 */
+
+/* Define to 1 if you have the <float.h> header file. */
+/* #undef HAVE_FLOAT_H */
+
+/* Define to 1 if you have the <ieeefp.h> header file. */
+/* #undef HAVE_IEEEFP_H */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+/* #define HAVE_INTTYPES_H */
+
+/* Define to 1 if you have the <math.h> header file. */
+/* #undef HAVE_MATH_H */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if function rand is available */
+#define HAVE_RAND 1
+
+/* Define to 1 if you have the <stdarg.h> header file. */
+/* #undef HAVE_STDARG_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+/* #undef HAVE_STDINT_H */
+
+/* Define to 1 if you have the <stdio.h> header file. */
+/* #undef HAVE_STDIO_H */
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if function std::rand is available */
+#define HAVE_STD__RAND 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #define HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <time.h> header file. */
+/* #undef HAVE_TIME_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #define HAVE_UNISTD_H */
+
+/* Define to 1 if va_copy is avaliable */
+/* #undef HAVE_VA_COPY */
+
+/* Define to 1 if you have the <windows.h> header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Define to 1 if you have the `_snprintf' function. */
+#define HAVE__SNPRINTF 1
+
+/* The size of a `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE 8
+
+/* The size of a `int', as computed by sizeof. */
+#define SIZEOF_INT 4
+
+/* The size of a `int *', as computed by sizeof. */
+#define SIZEOF_INT_P 8
+
+/* The size of a `long', as computed by sizeof. */
+#define SIZEOF_LONG 4
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1


### PR DESCRIPTION
While master branch has had VS2022 projects for some time, these were not in stable/2.11 since that was created before. 
Added also windows-ci build msvs for VS2022 like master.
Included configall_system for MSC as in master.

PR builds failed due to package names (the "/" in stable/2.11 made the original package name not valid). Fixed in Linux and Windows ci builds.

The aim is to get Cbc stable/2.10 and all (stable) dependencies to have VS2022 projects where currently none do. 
CoinUtils stable/2.11 is step 1.
