### PR TITLE
workaround for linker internal error on macos-13

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -29,7 +29,7 @@ jobs:
             download_requirements: brew install metis bash
           - os: macos-13
             build_static: false
-            flags: CC=gcc-13 CXX=g++-13 OSX=13
+            flags: CC=gcc-13 CXX=g++-13 OSX=13 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source


### PR DESCRIPTION
This workaround tries to address https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/26
An assertion failed with the linker "ld: Assertion failed: (resultIndex < sectData.atoms.size())"
Workarounds suggested on the internet are to "add -Wl,-ld_classic"
