### PR TITLE
Directly include cfloat and cmath

### DIFF
--- a/src/CoinFinite.cpp
+++ b/src/CoinFinite.cpp
@@ -5,21 +5,8 @@
 #include "CoinFinite.hpp"
 #include "CoinUtilsConfig.h"
 
-#ifdef HAVE_CFLOAT
 #include <cfloat>
-#else
-#ifdef HAVE_FLOAT_H
-#include <float.h>
-#endif
-#endif
-
-#ifdef HAVE_CMATH
 #include <cmath>
-#else
-#ifdef HAVE_MATH_H
-#include <math.h>
-#endif
-#endif
 
 #ifdef HAVE_CIEEEFP
 #include <cieeefp>


### PR DESCRIPTION
Other source files already assume that cfloat and cmath are available. So the same can be done here, too.