### PR TITLE
Update ci to update windows and ubuntu runners

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         build_static: [true, false]
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
-        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
+        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
           - os: macos-13
             build_static: false

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,10 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { os: windows-2019, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
-          { os: windows-2019, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
-          { os: windows-2019, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2022, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
+          { os: windows-2025, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
+          { os: windows-2025, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
           { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2025, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
         ]
     steps:
       - name: Checkout source
@@ -77,12 +78,12 @@ jobs:
       - name: Generate package name for msvc
         run: |
           msvc_version=${VisualStudioVersion%.*}
-          echo "package_suffix=w64-msvc${msvc_version}${{ matrix.suffix }}" >> $GITHUB_ENV
+          echo "package_suffix=${{ matrix.os}}-msvc${msvc_version}${{ matrix.suffix }}" >> $GITHUB_ENV
         shell: msys2 {0}
         if: ${{ matrix.arch == 'msvc' }}
       - name: Generate package name
         run: |
-          echo "package_suffix=${{ matrix.arch }}-w64-${{ matrix.msystem }}${{ matrix.suffix }}" >> $GITHUB_ENV
+          echo "package_suffix=${{ matrix.arch }}-${{ matrix.os}}-${{ matrix.msystem }}${{ matrix.suffix }}" >> $GITHUB_ENV
         shell: msys2 {0}
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,9 +21,8 @@ jobs:
       matrix:
         include: [
           { os: windows-2022, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
-          { os: windows-2025, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
           { os: windows-2025, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
-          { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2022, arch: msvc, msystem: mingw64, debug: true, suffix: "-dbg" },
           { os: windows-2025, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
         ]
     steps:
@@ -78,12 +77,12 @@ jobs:
       - name: Generate package name for msvc
         run: |
           msvc_version=${VisualStudioVersion%.*}
-          echo "package_suffix=${{ matrix.os}}-msvc${msvc_version}${{ matrix.suffix }}" >> $GITHUB_ENV
+          echo "package_suffix=w64-msvc${msvc_version}${{ matrix.suffix }}" >> $GITHUB_ENV
         shell: msys2 {0}
         if: ${{ matrix.arch == 'msvc' }}
       - name: Generate package name
         run: |
-          echo "package_suffix=${{ matrix.arch }}-${{ matrix.os}}-${{ matrix.msystem }}${{ matrix.suffix }}" >> $GITHUB_ENV
+          echo "package_suffix=${{ matrix.arch }}-w64-${{ matrix.msystem }}${{ matrix.suffix }}" >> $GITHUB_ENV
         shell: msys2 {0}
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -22,7 +22,7 @@ jobs:
         include: [
           # Only os: windows-2022 has Visual Studio 2022 (v17) installed with toolset v143, which is required.
           # configuration: "Release" or "Debug", platform: "x86" or "x64". See solution Configuration Manager.
-          { os: windows-2022, configuration: "Release", platform: "x64" },
+          { os: windows-2022, configuration: "Debug", platform: "x64" },
           { os: windows-2025, configuration: "Release", platform: "x64" }
         ]
     steps:

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -23,6 +23,7 @@ jobs:
           # Only os: windows-2022 has Visual Studio 2022 (v17) installed with toolset v143, which is required.
           # configuration: "Release" or "Debug", platform: "x86" or "x64". See solution Configuration Manager.
           { os: windows-2022, configuration: "Release", platform: "x64" },
+          { os: windows-2025, configuration: "Release", platform: "x64" }
         ]
     steps:
       - name: Set up environment variables


### PR DESCRIPTION
See also COIN-OR-OptimizationSuite [Issue 32](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/32) and [Issue 33](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/33): 
1. Remove Windows Server 2019 runner images for Actions are being deprecated in June 2025.
2. Add tests for the new Windows Server 2025 which was released Nov 2024.
3. Similarly, remove deprecated Ubuntu 20.04 and add new Ubuntu 24.04

These changes are done for linux-ci, windows-ci (using coinbrew) and windows-msvs-ci (using Visual Studio solutions) workflows.