### PR TITLE
stay in double to avoid overflow

### DIFF
--- a/src/CoinFactorization3.cpp
+++ b/src/CoinFactorization3.cpp
@@ -242,7 +242,7 @@ void CoinFactorization::updateColumnL(CoinIndexedVector *regionSparse,
     // Guess at number at end
     if (sparseThreshold_ > 0) {
       if (ftranAverageAfterL_) {
-        int newNumber = static_cast< int >(number * ftranAverageAfterL_);
+        double newNumber = number * ftranAverageAfterL_;
         if (newNumber < sparseThreshold_ && (numberL_ << 2) > newNumber)
           goSparse = 2;
         else if (newNumber < sparseThreshold2_ && (numberL_ << 1) > newNumber)
@@ -740,7 +740,7 @@ int goSparse = 0;
 if (sparseThreshold_ > 0) {
   int numberNonZero = (regionUpdate->getNumElements() + regionFT->getNumElements()) >> 1;
   if (ftranAverageAfterR_) {
-    int newNumber = static_cast< int >(numberNonZero * ftranAverageAfterU_);
+    double newNumber = numberNonZero * ftranAverageAfterU_;
     if (newNumber < sparseThreshold_)
       goSparse = 2;
     else if (newNumber < sparseThreshold2_)
@@ -1025,7 +1025,7 @@ void CoinFactorization::updateColumnU(CoinIndexedVector *regionSparse,
   // Guess at number at end
   if (sparseThreshold_ > 0) {
     if (ftranAverageAfterR_) {
-      int newNumber = static_cast< int >(numberNonZero * ftranAverageAfterU_);
+      double newNumber = numberNonZero * ftranAverageAfterU_;
       if (newNumber < sparseThreshold_)
         goSparse = 2;
       else if (newNumber < sparseThreshold2_)

--- a/src/CoinFactorization4.cpp
+++ b/src/CoinFactorization4.cpp
@@ -796,7 +796,7 @@ void CoinFactorization::replaceColumn1(CoinIndexedVector *regionSparse,
   // Guess at number at end
   if (sparseThreshold_ > 0) {
     if (btranAverageAfterU_) {
-      int newNumber = static_cast< int >(number * btranAverageAfterU_);
+      double newNumber = number * btranAverageAfterU_;
       if (newNumber < sparseThreshold_)
         goSparse = 2;
       else if (newNumber < sparseThreshold2_)
@@ -1946,7 +1946,7 @@ void CoinFactorization::updateColumnTransposeU(CoinIndexedVector *regionSparse,
   // Guess at number at end
   if (sparseThreshold_ > 0) {
     if (btranAverageAfterU_) {
-      int newNumber = static_cast< int >(number * btranAverageAfterU_);
+      double newNumber = number * btranAverageAfterU_;
       if (newNumber < sparseThreshold_)
         goSparse = 2;
       else if (newNumber < sparseThreshold2_)
@@ -2287,7 +2287,7 @@ void CoinFactorization::updateColumnTransposeL(CoinIndexedVector *regionSparse) 
   // we may need to rethink on dense
   if (sparseThreshold_ > 0) {
     if (btranAverageAfterL_) {
-      int newNumber = static_cast< int >(number * btranAverageAfterL_);
+      double newNumber = number * btranAverageAfterL_;
       if (newNumber < sparseThreshold_)
         goSparse = 2;
       else if (newNumber < sparseThreshold2_)


### PR DESCRIPTION
CoinUtils/src/CoinFactorization4.cpp:2290:42: runtime error: 2.28294e+09 is outside the range of representable values of type 'int'