### PR TITLE
Fix warning C4244 '=': conversion from '__int64' to 'int, possible loss of data in MSVC

### DIFF
--- a/src/CoinOslFactorization2.cpp
+++ b/src/CoinOslFactorization2.cpp
@@ -503,8 +503,8 @@ static int c_ekkbtj4p_dense(const int nrow, const double *COIN_RESTRICT dluval,
     dv2 = densew[0];
     for (k = 0; k < nincol; k++) {
 #ifdef DEBUG
-      int kk = dlu1 - dluval;
-      int jj = (densew + (nincol - k + 1)) - dwork1;
+      intptr_t kk = dlu1 - dluval;
+      intptr_t jj = (densew + (nincol - k + 1)) - dwork1;
       int ll = hrowi[k + kk];
       if (ll != jj)
         abort();


### PR DESCRIPTION
Fix warning C4244 '=': conversion from '__int64' to 'int, possible loss of data in MSVC building for x86_64 architecture.