### PR TITLE
Fix blocking of Windows Error popups and use in unitTest.

### DIFF
--- a/src/CoinError.cpp
+++ b/src/CoinError.cpp
@@ -8,12 +8,14 @@ bool COINUTILSLIB_EXPORT CoinError::printErrors_ = false;
 
 /** A function to block the popup windows that windows creates when the code
     crashes */
-#ifdef HAVE_WINDOWS_H
+#ifdef _MSC_VER
 #include <windows.h>
+#include <stdlib.h>
 COINUTILSLIB_EXPORT
 void WindowsErrorPopupBlocker()
 {
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+  _set_abort_behavior(0, _WRITE_ABORT_MSG);
 }
 #else
 COINUTILSLIB_EXPORT

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -52,6 +52,9 @@ void testingMessage( const char * const msg );
 
 int main (int argc, const char *argv[])
 {
+  // Stop Windows popup
+  WindowsErrorPopupBlocker();
+  
   /*
     Set default location for Data directory, assuming traditional
     package layout.


### PR DESCRIPTION
The existing WindowsErrorPopupBlocker() in CoinError.cpp was not actually blocking the Microsoft Visual C++ Runtime Library popups when an assert failed. This is now fixed. Also, the popup blocker is called in CoinUtils unitTest.

Especially during unattended runs, like Github Actions, the popup causes the run to hang until a timeout occurs after 6h for MSVC-based runs in case an assert fails. See [an example with Cbc](https://github.com/coin-or/Cbc/actions/runs/20358240373/job/59374957533).
