### PR TITLE
Remove COINUTILSLIB_EXPORT for cointerm member.

### DIFF
--- a/src/CoinTerm.hpp
+++ b/src/CoinTerm.hpp
@@ -39,7 +39,7 @@ struct COINUTILSLIB_EXPORT CoinTerm {
     }
   };
 
-  static COINUTILSLIB_EXPORT constexpr AscendingValueThenIndexComparator AscendingValueThenIndex = AscendingValueThenIndexComparator();
+  static constexpr AscendingValueThenIndexComparator AscendingValueThenIndex = AscendingValueThenIndexComparator();
 };
 
 #endif // COIN_TERM_HPP


### PR DESCRIPTION
Related to Issue #256 to resolve DLL-related compiler error.