### PR TITLE
Update linux-ci to add macos-26 and action updates for Node 24

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -24,28 +24,36 @@ jobs:
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
-          - os: macos-15-intel
+          - os: macos-26-intel
             build_static: false
-            flags: CC=clang CXX=clang++ OSX=15
+            flags: CC=clang CXX=clang++
             download_requirements: brew install metis bash
           - os: macos-15-intel
             build_static: false
-            flags: CC=gcc-15 CXX=g++-15 OSX=15 ADD_CXXFLAGS=-Wl,-ld_classic
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash
+          - os: macos-26
+            build_static: false
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
+            download_requirements: brew install metis bash
+          - os: macos-15
+            build_static: false
+            flags: CC=clang CXX=clang++
             download_requirements: brew install metis bash
           - os: macos-14
             arch: arm64
             build_static: false
-            flags: CC=gcc-13 CXX=g++-13 OSX=14 ADD_CXXFLAGS=-Wl,-ld_classic
+            flags: CC=gcc-13 CXX=g++-13 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}
       - name: Install required packages from package manager
         run: ${{ matrix.download_requirements }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -72,7 +80,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
           tar -czvf release.tar.gz -C dist .
       - name: Checkout package name generation script
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or-tools/platform-analysis-tools
           path: tools
@@ -86,7 +94,7 @@ jobs:
           platform_str=`python3 tools/hsf_get_platform.py -b $buildtype`
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -28,11 +28,11 @@ jobs:
         ]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -70,7 +70,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
         shell: msys2 {0}
       - name: Upload failed build directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: ${{ matrix.os}}-{{ matrix.arch }}-debug=${{ matrix.debug }}-failedbuild

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -87,7 +87,7 @@ jobs:
         shell: msys2 {0}
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ env.package_suffix }}
           path: dist

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -41,16 +41,16 @@ jobs:
           echo Package suffix - '${{ env.package_suffix }}'
           if "${{ env.output_dir }}"=="" echo ERROR - No output_dir set, possibly unsupported platform '${{ matrix.platform }}'. Expecting x64 or x86. && exit 1
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or/coinbrew
           path: coinbrew
       - name: Set up msbuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
       - name: Set up msys for coinbrew
         uses: msys2/setup-msys2@v2
         with:
@@ -94,7 +94,7 @@ jobs:
           if exist .\Data\Netlib xcopy .\Data\Netlib dist\share\coin-or-netlib /i
           if exist .\Data\Miplib3 xcopy .\Data\Miplib3 dist\share\coin-or-miplib3 /i
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ env.package_suffix }}
           path: dist


### PR DESCRIPTION
- Update linux-ci to add the new macos-26 and macos-26-intel runners.
-- Simplify the combinations of macos and compilers (gcc / clang)
-- Remove "OSX=xx" flags. It seems not used?
-- Remove "arch: arm64" for macos-14. It seems not used?
See also https://docs.github.com/en/actions/reference/runners/github-hosted-runners

- Update update all ci.yml for several actions to recent versions that use Node 24 rather than the old Node 20. See recent Action warnings.