### PR TITLE
Update linux-ci to trim the number of macos builds

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -28,10 +28,6 @@ jobs:
             build_static: false
             flags: CC=clang CXX=clang++
             download_requirements: brew install metis bash
-          - os: macos-15-intel
-            build_static: false
-            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash
           - os: macos-26
             build_static: false
             flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
@@ -40,11 +36,7 @@ jobs:
             build_static: false
             flags: CC=clang CXX=clang++
             download_requirements: brew install metis bash
-          - os: macos-14
-            arch: arm64
-            build_static: false
-            flags: CC=gcc-13 CXX=g++-13 ADD_CXXFLAGS=-Wl,-ld_classic
-            download_requirements: brew install metis bash
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v6


### PR DESCRIPTION
Reduce the number of MaxOS builds to only the two most recent MacOS, and intel only for the latest MacOS:
```
       - os: macos-26-intel
          flags: CC=clang CXX=clang++
       - os: macos-26
          flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
       - os: macos-15
          flags: CC=clang CXX=clang++
```

See also [COIN-OR-OptimizationSuite issue 36](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/36) discussion.
At the time of writing, the "macos-latest" workflow label resolves to [macos-15](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).